### PR TITLE
chore: scaffold project structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm test

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,3 @@
+# Mobile App
+
+Future Expo/React Native application.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Keep Moving Web App</h1>
+      <p>Welcome to the web MVP.</p>
+    </main>
+  );
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@keep-moving/web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {}
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+Docker, deployment, and other infrastructure configurations will live here.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "keep-moving",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["apps/*", "services/*", "packages/*"],
+  "scripts": {
+    "test": "echo \"No tests yet\""
+  }
+}

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keep-moving/api-client",
+  "version": "0.1.0",
+  "main": "src/index.ts"
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,1 @@
+export const apiClient = {};

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keep-moving/config",
+  "version": "0.1.0",
+  "main": "src/index.ts"
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,1 @@
+export const config = {};

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keep-moving/schema",
+  "version": "0.1.0",
+  "main": "src/index.ts"
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholderSchema = {};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keep-moving/ui",
+  "version": "0.1.0",
+  "main": "src/index.tsx"
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,3 @@
+export const Placeholder = () => {
+  return <div>UI components go here</div>;
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keep-moving/utils",
+  "version": "0.1.0",
+  "main": "src/index.ts"
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export const noop = () => {};

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Keep Moving API"}

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "keep-moving-api"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]"
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "lint": {},
+    "test": {}
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold turborepo-style monorepo with apps, services, packages, infra, and CI directories
- add placeholder Next.js web app and FastAPI API stubs
- create shared package stubs for ui, schema, api client, utils, and config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc425680b4832db734768047159f94