### PR TITLE
Fix web package.json syntax

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,6 @@
     "start": "next start"
   },
   "dependencies": {
-
     "@clerk/nextjs": "^6.31.9",
     "@stripe/stripe-js": "^1.54.0",
     "next": "^15.2.3",
@@ -17,8 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.0",
-
     "typescript": "^5.9.2",
     "@types/react": "^18.3.24"
   }
-
+}


### PR DESCRIPTION
## Summary
- fix missing closing bracket in web workspace `package.json`

## Testing
- `npm install`
- `npm test`
- `npm run build` *(fails: Missing Clerk publishableKey)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb922b758832db96c5cba8a7c3e4c