### PR TITLE
Fix web package.json syntax and add quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
 # Keep Moving Fitness Platform
 
-A cross-platform fitness and community app.  
-**Phase 1:** Web (Next.js) MVP.  
+A cross-platform fitness and community app.
+**Phase 1:** Web (Next.js) MVP.
 **Future:** Native iOS + Android (Expo/React Native) using the same UI + API layers.
+
+## Quick Start
+
+Launch the web app and API locally:
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   python -m venv .venv && source .venv/bin/activate
+   pip install -e services/api
+   ```
+2. **Start the Next.js web app**
+   ```bash
+   npm run dev --workspace @keep-moving/web
+   ```
+3. **Start the FastAPI backend**
+   ```bash
+   uvicorn app.main:app --reload
+   ```
 
 ---
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,6 @@
     "start": "next start"
   },
   "dependencies": {
-
     "@clerk/nextjs": "^6.31.9",
     "@stripe/stripe-js": "^1.54.0",
     "next": "^15.2.3",
@@ -17,8 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.0",
-
     "typescript": "^5.9.2",
     "@types/react": "^18.3.24"
   }
-
+}


### PR DESCRIPTION
## Summary
- fix missing closing bracket in web workspace `package.json`
- add README quick start instructions for launching web and API locally

## Testing
- `npm install`
- `npm test`
- `pip install -e services/api`
- `npm run build --workspace @keep-moving/web` *(fails: Missing publishableKey)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb922b758832db96c5cba8a7c3e4c